### PR TITLE
refactor: fix PostgreSQL driver-class typo and align env vars with standard naming

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,13 +6,17 @@ spring:
 
   datasource:
     url: jdbc:postgresql://localhost:${POSTGRES_PORT}/${POSTGRES_DB}
-    username: ${POSTGRES_USERNAME}
+    username: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
-    driver-class-name: org.postgres.Driver
+    driver-class-name: org.postgresql.Driver
     pool-size: 30
 
   jpa:
     hibernate:
       ddl-auto: update
     show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
 


### PR DESCRIPTION
    - Corrected `driver-class-name` from `org.postgres.Driver` to `org.postgresql.Driver` to fix misconfiguration.

    - Updated `username` key to use `${POSTGRES_USER}` instead of `${POSTGRES_USERNAME}` for consistency with common vironment variable naming.

    - Added `hibernate.dialect` property to explicitly set `PostgreSQLDialect`, improving Hibernate compatibility and SQL generation.