### PR TITLE
feat: add request and response DTOs for spreadsheet data

### DIFF
--- a/src/main/java/com/demo/sheetsync/model/entity/dto/request/SpreadSheetDataRequest.java
+++ b/src/main/java/com/demo/sheetsync/model/entity/dto/request/SpreadSheetDataRequest.java
@@ -1,0 +1,15 @@
+package com.demo.sheetsync.model.entity.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SpreadSheetDataRequest {
+
+    private String spreadSheetId;
+}

--- a/src/main/java/com/demo/sheetsync/model/entity/dto/response/SpreadSheetDataResponse.java
+++ b/src/main/java/com/demo/sheetsync/model/entity/dto/response/SpreadSheetDataResponse.java
@@ -1,0 +1,22 @@
+package com.demo.sheetsync.model.entity.dto.response;
+
+import com.demo.sheetsync.model.entity.Sheet;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SpreadSheetDataResponse {
+
+    private String spreadsheetId;
+
+    private String title;
+
+    private List<Sheet> sheets;
+}


### PR DESCRIPTION
    - Added `SpreadSheetDataRequest` to encapsulate the spreadsheet ID in incoming requests.
    - Added `SpreadSheetDataResponse` to return spreadsheet metadata including ID, title, and associated sheets.
    - These DTOs support cleaner separation of concerns between internal models and API contracts.