### PR TITLE
feat: add mappers for converting Google Spreadsheet API to internal m…

### DIFF
--- a/src/main/java/com/demo/sheetsync/model/entity/dto/mapper/GoogleSpreadsheetMapper.java
+++ b/src/main/java/com/demo/sheetsync/model/entity/dto/mapper/GoogleSpreadsheetMapper.java
@@ -1,0 +1,26 @@
+package com.demo.sheetsync.model.entity.dto.mapper;
+
+import com.demo.sheetsync.model.entity.SpreadSheet;
+import com.google.api.services.sheets.v4.model.Spreadsheet;
+import lombok.RequiredArgsConstructor;
+
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class GoogleSpreadsheetMapper {
+
+    private final GoogleSheetMapper googleSheetMapper;
+
+    public SpreadSheet maptoEntity(Spreadsheet googleSpreadsheet){
+
+        return SpreadSheet.builder()
+                .spreadsheetId(googleSpreadsheet.getSpreadsheetId())
+                .title(googleSpreadsheet.getProperties().getTitle())
+                .sheets(googleSpreadsheet.getSheets()
+                        .stream()
+                        .map(sheet -> googleSheetMapper
+                                .mapToEntity(sheet, googleSpreadsheet))
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/demo/sheetsync/model/entity/dto/mapper/SpreadSheetDataMapper.java
+++ b/src/main/java/com/demo/sheetsync/model/entity/dto/mapper/SpreadSheetDataMapper.java
@@ -1,0 +1,19 @@
+package com.demo.sheetsync.model.entity.dto.mapper;
+
+import com.demo.sheetsync.model.entity.SpreadSheet;
+import com.demo.sheetsync.model.entity.dto.response.SpreadSheetDataResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpreadSheetDataMapper {
+
+    public SpreadSheetDataResponse toResponse(SpreadSheet spreadSheet){
+
+        return new SpreadSheetDataResponse(
+                spreadSheet.getSpreadsheetId(),
+                spreadSheet.getTitle(),
+                spreadSheet.getSheets()
+        );
+
+    }
+}


### PR DESCRIPTION
…odels

    - Added GoogleSpreadsheetMapper to map Google Sheets API's Spreadsheet to SpreadSheet entity
    - Injected GoogleSheetMapper to convert individual Sheet elements
    - Created SpreadSheetDataMapper to map SpreadSheet entity to SpreadSheetDataResponse DTO
    - Supports separation of concerns and improves testability of transformation logic