### PR TITLE
feat: add GoogleSheetMapper to convert Sheets API data into Sheet entity

### DIFF
--- a/src/main/java/com/demo/sheetsync/model/entity/dto/mapper/GoogleSheetMapper.java
+++ b/src/main/java/com/demo/sheetsync/model/entity/dto/mapper/GoogleSheetMapper.java
@@ -1,0 +1,26 @@
+package com.demo.sheetsync.model.entity.dto.mapper;
+
+import com.demo.sheetsync.model.entity.Sheet;
+import com.google.api.services.sheets.v4.model.Spreadsheet;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+
+@RequiredArgsConstructor
+public class GoogleSheetMapper {
+
+    private final GoogleSpreadsheetMapper googleSpreadsheetMapper;
+
+    public Sheet mapToEntity(com.google.api.services.sheets.v4.model.Sheet googleSheet,
+                             Spreadsheet parentGoogleSpreadSheet){
+
+        return Sheet.builder()
+                .sheetId(googleSheet.getProperties().getSheetId())
+                .title(googleSheet.getProperties().getTitle())
+                .headers(new ArrayList<>())
+                .rows(new ArrayList<>())
+                .spreadSheet(googleSpreadsheetMapper.maptoEntity(parentGoogleSpreadSheet))
+                .build();
+    }
+
+}


### PR DESCRIPTION
    - Introduced GoogleSheetMapper to map a single Google Sheet and its metadata into a Sheet entity
    - Uses parent Spreadsheet to associate Sheet with its corresponding SpreadSheet entity
    - Initializes headers and rows as empty lists for later population