### PR TITLE
test: add unit and integration tests for SpreadSheetService

### DIFF
--- a/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceIntegrationTest.java
+++ b/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceIntegrationTest.java
@@ -1,0 +1,96 @@
+package com.demo.sheetsync.service;
+
+import com.demo.sheetsync.model.entity.SpreadSheet;
+import com.demo.sheetsync.model.entity.dto.mapper.GoogleSpreadsheetMapper;
+import com.demo.sheetsync.model.entity.dto.request.SpreadSheetDataRequest;
+import com.demo.sheetsync.model.entity.dto.response.SpreadSheetDataResponse;
+import com.demo.sheetsync.repository.SpreadSheetRepository;
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.Spreadsheet;
+import com.google.api.services.sheets.v4.model.SpreadsheetProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
+@Import(TestcontainersConfiguration.class)
+public class SpreadSheetServiceIntegrationTest {
+
+    @Autowired
+    SpreadSheetRepository repository;
+
+    @Autowired
+    SpreadSheetService service;
+
+    @MockitoBean
+    GoogleSpreadsheetMapper googleMapper;
+
+    @MockitoBean
+    Sheets sheets;
+
+    @Test
+    void should_save_and_return_spreadsheet_response() throws IOException {
+
+        //Given
+        String spreadSheetId = "test_spreadSheet_id";
+        SpreadSheetDataRequest request = new SpreadSheetDataRequest();
+        request.setSpreadSheetId(spreadSheetId);
+
+        Spreadsheet googleSpreadsheet = new Spreadsheet();
+        googleSpreadsheet.setSpreadsheetId("test_spreadSheet_id");
+        googleSpreadsheet.setProperties(new SpreadsheetProperties()
+                .setTitle("test sheet"));
+
+        SpreadSheet entity = SpreadSheet.builder()
+                .id(null)
+                .spreadsheetId(spreadSheetId)
+                .title("test sheet")
+                .sheets(new ArrayList<>())
+                .build();
+
+        //Mock Sheets
+        Sheets.Spreadsheets spreadsheets = mock(Sheets.Spreadsheets.class);
+        Sheets.Spreadsheets.Get get = mock(Sheets.Spreadsheets.Get.class);
+
+        when(sheets.spreadsheets()).thenReturn(spreadsheets);
+        when(spreadsheets.get(spreadSheetId)).thenReturn(get);
+        when(get.execute()).thenReturn(googleSpreadsheet);
+
+        //Mock mapper behavior
+        when(googleMapper.maptoEntity(googleSpreadsheet)).thenReturn(entity);
+
+        //When
+        SpreadSheetDataResponse result = service.saveSpreadSheet(request);
+
+        //Then
+        assertNotNull(result);
+        assertEquals("test sheet", result.getTitle());
+        assertEquals(spreadSheetId, result.getSpreadsheetId());
+
+        //check persistence
+        List<SpreadSheet> all = repository.findAll();
+        assertEquals(1, all.size());
+        SpreadSheet saved = all.get(0);
+        assertEquals("test sheet", saved.getTitle());
+        assertEquals(spreadSheetId, saved.getSpreadsheetId());
+    }
+
+
+
+}

--- a/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceTest.java
+++ b/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceTest.java
@@ -1,0 +1,94 @@
+package com.demo.sheetsync.service;
+
+import com.demo.sheetsync.model.entity.SpreadSheet;
+import com.demo.sheetsync.model.entity.dto.mapper.GoogleSpreadsheetMapper;
+import com.demo.sheetsync.model.entity.dto.mapper.SpreadSheetDataMapper;
+import com.demo.sheetsync.model.entity.dto.request.SpreadSheetDataRequest;
+import com.demo.sheetsync.model.entity.dto.response.SpreadSheetDataResponse;
+import com.demo.sheetsync.repository.SpreadSheetRepository;
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.Spreadsheet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SpreadSheetServiceTest {
+
+    @Mock
+    SpreadSheetRepository repository;
+
+    @Mock
+    GoogleSpreadsheetMapper googleSpreadsheetMapper;
+
+    @Mock
+    SpreadSheetDataMapper spreadSheetDataMapper;
+
+    @Mock
+    Sheets sheets;
+
+    @Mock
+    Sheets.Spreadsheets spreadsheets;
+
+    @Mock
+    Sheets.Spreadsheets.Get getRequest;
+
+    @InjectMocks
+    SpreadSheetService service;
+
+    @Test
+    void should_save_spreadSheet() throws IOException {
+
+        //Arrange
+        String spreadSheetId = "test_spreadSheet_id";
+
+        SpreadSheetDataRequest request =
+                new SpreadSheetDataRequest(spreadSheetId);
+
+        Spreadsheet googleSpreadsheet = new Spreadsheet();
+
+        SpreadSheet spreadSheetEntity = new SpreadSheet();
+
+        SpreadSheet savedEntity = new SpreadSheet();
+
+        SpreadSheetDataResponse response =
+                new SpreadSheetDataResponse();
+
+        when(sheets.spreadsheets()).thenReturn(spreadsheets);
+        when(spreadsheets.get(spreadSheetId)).thenReturn(getRequest);
+        when(getRequest.execute()).thenReturn(googleSpreadsheet);
+
+        when(googleSpreadsheetMapper
+                .maptoEntity(googleSpreadsheet))
+                .thenReturn(spreadSheetEntity);
+
+        when(repository.save(spreadSheetEntity)).thenReturn(savedEntity);
+
+        when(spreadSheetDataMapper
+                .toResponse(savedEntity)).thenReturn(response);
+
+        //Act
+        SpreadSheetDataResponse result = service.saveSpreadSheet(request);
+
+        //Assert
+        assertEquals(response, result);
+
+        verify(sheets.spreadsheets()).get(spreadSheetId);
+        verify(getRequest).execute();
+
+        verify(googleSpreadsheetMapper).maptoEntity(googleSpreadsheet);
+
+        verify(repository).save(spreadSheetEntity);
+
+        verify(spreadSheetDataMapper).toResponse(savedEntity);
+    }
+
+}


### PR DESCRIPTION
    - Added SpreadSheetServiceTest using Mockito to validate logic in isolation - Mocks dependencies: repository, mappers, Sheets API - Verifies interactions and response mapping for saveSpreadSheet()

    - Added SpreadSheetServiceIntegrationTest using Testcontainers and Spring context
      - Mocks Google Sheets API response
      - Tests actual saving to repository and full service behavior