### PR TITLE
feat: add SpreadSheetController with GET endpoint to save spreadsheet by spreadsheetID

### DIFF
--- a/src/main/java/com/demo/sheetsync/controller/SpreadSheetController.java
+++ b/src/main/java/com/demo/sheetsync/controller/SpreadSheetController.java
@@ -1,0 +1,24 @@
+package com.demo.sheetsync.controller;
+
+import com.demo.sheetsync.model.entity.dto.response.SpreadSheetDataResponse;
+import com.demo.sheetsync.service.SpreadSheetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(path = "api/v1/spreadsheet")
+public class SpreadSheetController {
+
+    private final SpreadSheetService service;
+
+    @GetMapping("/{spreadSheetId}")
+    public ResponseEntity<SpreadSheetDataResponse> save(@PathVariable String spreadSheetId) {
+
+        return ResponseEntity.ok(
+                service.saveSpreadSheet(spreadSheetId)
+        );
+
+    }
+}


### PR DESCRIPTION
    - Introduced SpreadSheetController with endpoint: GET /api/v1/spreadsheet/{spreadSheetId}
    - Delegates to SpreadSheetService to fetch and persist Google Spreadsheet data
    - Returns SpreadSheetDataResponse as HTTP response