### PR TITLE
feat: add GoogleSheetsService to encapsulate Google Sheets API access logic

### DIFF
--- a/src/main/java/com/demo/sheetsync/service/GoogleSheetsService.java
+++ b/src/main/java/com/demo/sheetsync/service/GoogleSheetsService.java
@@ -1,0 +1,45 @@
+package com.demo.sheetsync.service;
+
+import com.demo.sheetsync.exception.GoogleSheetAccessException;
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.Spreadsheet;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleSheetsService {
+
+    private final Sheets sheets;
+    private static final Logger logger = LoggerFactory.getLogger(SpreadSheetService.class);
+
+
+    private Spreadsheet tryGetGoogleSpreadSheet(String spreadSheetId){
+
+        try {
+
+            return sheets.spreadsheets()
+                    .get(spreadSheetId)
+                    .execute();
+
+        } catch (IOException e){
+
+            String msg = "Something went wrong retrieving spreadsheet with ID: "
+                    + spreadSheetId;
+
+            logger.error(msg, e);
+            throw new GoogleSheetAccessException(msg, e);
+        }
+
+    }
+
+    protected Spreadsheet getGoogleSpreadSheet(String spreadSheetId){
+
+        return tryGetGoogleSpreadSheet(spreadSheetId);
+    }
+
+}


### PR DESCRIPTION
    - Introduced GoogleSheetsService as a dedicated service to retrieve Google Spreadsheets via Sheets API
    - Handles exceptions and logging for spreadsheet access
    - Provides getGoogleSpreadSheet(String spreadSheetId) method as public API
    - Extracted logic previously in SpreadSheetService for better separation of concerns