### PR TITLE
refactor: extract Google Sheets API logic to GoogleSheetsService

### DIFF
--- a/src/main/java/com/demo/sheetsync/service/SpreadSheetService.java
+++ b/src/main/java/com/demo/sheetsync/service/SpreadSheetService.java
@@ -22,17 +22,15 @@ import java.io.IOException;
 public class SpreadSheetService {
 
     private final SpreadSheetRepository repository;
-    private final Sheets sheets;
-
     private final GoogleSpreadsheetMapper googleSpreadsheetMapper;
-
     private final SpreadSheetDataMapper spreadSheetDataMapper;
+    private final GoogleSheetsService googleSheetsService;
 
-    private static final Logger logger = LoggerFactory.getLogger(SpreadSheetService.class);
 
     public SpreadSheetDataResponse saveSpreadSheet(String spreadSheetId)  {
 
-        Spreadsheet googleSpreadSheet = tryGetGoogleSpreadSheet(spreadSheetId);
+        Spreadsheet googleSpreadSheet = googleSheetsService
+                .getGoogleSpreadSheet(spreadSheetId);
 
         SpreadSheet spreadSheet = googleSpreadsheetMapper.maptoEntity(googleSpreadSheet);
 
@@ -41,24 +39,6 @@ public class SpreadSheetService {
 
     }
 
-    private Spreadsheet tryGetGoogleSpreadSheet(String spreadSheetId){
-
-        try {
-
-            return sheets.spreadsheets()
-                    .get(spreadSheetId)
-                    .execute();
-
-        } catch (IOException e){
-
-            String msg = "Something went wrong retrieving spreadsheet with ID: "
-                    + spreadSheetId;
-
-            logger.error(msg, e);
-            throw new GoogleSheetAccessException(msg, e);
-        }
-
-    }
 
 
 }

--- a/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceIntegrationTest.java
+++ b/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceIntegrationTest.java
@@ -34,15 +34,12 @@ public class SpreadSheetServiceIntegrationTest {
 
     @Autowired
     SpreadSheetRepository repository;
-
     @Autowired
     SpreadSheetService service;
-
     @MockitoBean
     GoogleSpreadsheetMapper googleMapper;
-
     @MockitoBean
-    Sheets sheets;
+    GoogleSheetsService googleSheetsService;
 
     @Test
     void should_save_and_return_spreadsheet_response() throws IOException {
@@ -62,13 +59,9 @@ public class SpreadSheetServiceIntegrationTest {
                 .sheets(new ArrayList<>())
                 .build();
 
-        //Mock Sheets
-        Sheets.Spreadsheets spreadsheets = mock(Sheets.Spreadsheets.class);
-        Sheets.Spreadsheets.Get get = mock(Sheets.Spreadsheets.Get.class);
-
-        when(sheets.spreadsheets()).thenReturn(spreadsheets);
-        when(spreadsheets.get(spreadSheetId)).thenReturn(get);
-        when(get.execute()).thenReturn(googleSpreadsheet);
+        when(googleSheetsService
+                .getGoogleSpreadSheet(spreadSheetId))
+                .thenReturn(googleSpreadsheet);
 
         //Mock mapper behavior
         when(googleMapper.maptoEntity(googleSpreadsheet)).thenReturn(entity);

--- a/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceTest.java
+++ b/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceTest.java
@@ -33,13 +33,10 @@ class SpreadSheetServiceTest {
     SpreadSheetDataMapper spreadSheetDataMapper;
 
     @Mock
-    Sheets sheets;
+    GoogleSheetsService googleSheetsService;
 
     @Mock
-    Sheets.Spreadsheets spreadsheets;
-
-    @Mock
-    Sheets.Spreadsheets.Get getRequest;
+    Spreadsheet spreadsheet;
 
     @InjectMocks
     SpreadSheetService service;
@@ -59,9 +56,8 @@ class SpreadSheetServiceTest {
         SpreadSheetDataResponse response =
                 new SpreadSheetDataResponse();
 
-        when(sheets.spreadsheets()).thenReturn(spreadsheets);
-        when(spreadsheets.get(spreadSheetId)).thenReturn(getRequest);
-        when(getRequest.execute()).thenReturn(googleSpreadsheet);
+        when(googleSheetsService.getGoogleSpreadSheet(spreadSheetId))
+                .thenReturn(googleSpreadsheet);
 
         when(googleSpreadsheetMapper
                 .maptoEntity(googleSpreadsheet))
@@ -78,8 +74,7 @@ class SpreadSheetServiceTest {
         //Assert
         assertEquals(response, result);
 
-        verify(sheets.spreadsheets()).get(spreadSheetId);
-        verify(getRequest).execute();
+        verify(googleSheetsService).getGoogleSpreadSheet(spreadSheetId);
 
         verify(googleSpreadsheetMapper).maptoEntity(googleSpreadsheet);
 


### PR DESCRIPTION
    - Removed direct dependency on Sheets API from SpreadSheetService
    - Delegated spreadsheet retrieval logic to a new GoogleSheetsService class
    - Updated tests to mock GoogleSheetsService instead of Sheets
    - Simplifies service logic and improves separation of concerns