### PR TITLE
feat: rename Sheet entity to SheetApp across the codebase

### DIFF
--- a/src/main/java/com/demo/sheetsync/model/entity/Sheet.java
+++ b/src/main/java/com/demo/sheetsync/model/entity/Sheet.java
@@ -19,7 +19,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class Sheet {
+public class SheetApp {
 
     @Id
     @GeneratedValue (strategy = GenerationType.IDENTITY)
@@ -41,5 +41,5 @@ public class Sheet {
 
     @ManyToOne
     @JoinColumn(name = "spreadsheet_id", nullable = false)
-    private SpreadSheet spreadSheet;
+    private SpreadSheetApp spreadSheet;
 }

--- a/src/main/java/com/demo/sheetsync/repository/SheetRepository.java
+++ b/src/main/java/com/demo/sheetsync/repository/SheetRepository.java
@@ -1,11 +1,11 @@
 package com.demo.sheetsync.repository;
 
-import com.demo.sheetsync.model.entity.Sheet;
+import com.demo.sheetsync.model.entity.SheetApp;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SheetRepository extends JpaRepository<Sheet, Integer> {
+public interface SheetRepository extends JpaRepository<SheetApp, Integer> {
 
 
 }

--- a/src/test/java/com/demo/sheetsync/repository/SheetRepositoryTest.java
+++ b/src/test/java/com/demo/sheetsync/repository/SheetRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.demo.sheetsync.repository;
 
-import com.demo.sheetsync.model.entity.Sheet;
-import com.demo.sheetsync.model.entity.SpreadSheet;
+import com.demo.sheetsync.model.entity.SheetApp;
+import com.demo.sheetsync.model.entity.SpreadSheetApp;
 import com.github.dockerjava.api.exception.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,8 +33,8 @@ class SheetRepositoryTest {
     @BeforeEach
     void setUp() {
 
-        //We save a spreadsheet before interact with the Sheet to apply the relation between them
-        spreadSheetRepository.save(SpreadSheet.builder()
+        //We save a spreadsheet before interact with the SheetApp to apply the relation between them
+        spreadSheetRepository.save(SpreadSheetApp.builder()
                 .spreadsheetId("spreadSheetMockId")
                 .title("testTitle")
                 .build());
@@ -59,15 +59,15 @@ class SheetRepositoryTest {
 
         data.add(row);
 
-        //Get the SpreadSheet saved previously
-        SpreadSheet spreadSheet = spreadSheetRepository
+        //Get the SpreadSheetApp saved previously
+        SpreadSheetApp spreadSheet = spreadSheetRepository
                 .findById(1)
                 .orElseThrow(() -> new NotFoundException(
                         "spreadSheet Not Found"
                 ));
 
-        //Save the Sheet with the related SpreadSheet saved previously
-        Sheet sheet = Sheet.builder()
+        //Save the SheetApp with the related SpreadSheetApp saved previously
+        SheetApp sheet = SheetApp.builder()
                 .sheetId(1234)
                 .headers(headers)
                 .spreadSheet(spreadSheet)
@@ -79,9 +79,9 @@ class SheetRepositoryTest {
         sheetRepository.save(sheet);
 
         //Then
-        Sheet savedSheet = sheetRepository.findById(1)
+        SheetApp savedSheet = sheetRepository.findById(1)
                 .orElseThrow(() -> new NotFoundException(
-                        "Sheet not found"
+                        "SheetApp not found"
                 ));
 
         assertThat(savedSheet.getRows()).isEqualTo(data);


### PR DESCRIPTION
    - Renamed the Sheet entity class to SheetApp to align with the domain naming conventions.
    - Updated SheetRepository to use SheetApp instead of Sheet.
    - Adjusted entity relationship from SpreadSheet to SpreadSheetApp.
    - Updated all relevant imports and references in SheetRepositoryTest to reflect the renaming.