### PR TITLE
refactor: update mappers to use renamed entities SheetApp and SpreadSheetApp

### DIFF
--- a/src/main/java/com/demo/sheetsync/model/mapper/GoogleSheetMapper.java
+++ b/src/main/java/com/demo/sheetsync/model/mapper/GoogleSheetMapper.java
@@ -1,7 +1,7 @@
 package com.demo.sheetsync.model.mapper;
 
-import com.demo.sheetsync.model.entity.Sheet;
-import com.demo.sheetsync.model.entity.SpreadSheet;
+import com.demo.sheetsync.model.entity.SheetApp;
+import com.demo.sheetsync.model.entity.SpreadSheetApp;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,10 +11,10 @@ import java.util.ArrayList;
 @RequiredArgsConstructor
 public class GoogleSheetMapper {
 
-    public Sheet mapToEntity(com.google.api.services.sheets.v4.model.Sheet googleSheet,
-                             SpreadSheet parentSpreadSheet){
+    public SheetApp mapToEntity(com.google.api.services.sheets.v4.model.Sheet googleSheet,
+                                SpreadSheetApp parentSpreadSheet){
 
-        return Sheet.builder()
+        return SheetApp.builder()
                 .sheetId(googleSheet.getProperties().getSheetId())
                 .title(googleSheet.getProperties().getTitle())
                 .headers(new ArrayList<>())

--- a/src/main/java/com/demo/sheetsync/model/mapper/GoogleSpreadsheetMapper.java
+++ b/src/main/java/com/demo/sheetsync/model/mapper/GoogleSpreadsheetMapper.java
@@ -1,6 +1,6 @@
 package com.demo.sheetsync.model.mapper;
 
-import com.demo.sheetsync.model.entity.SpreadSheet;
+import com.demo.sheetsync.model.entity.SpreadSheetApp;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,9 +11,9 @@ import java.util.ArrayList;
 @RequiredArgsConstructor
 public class GoogleSpreadsheetMapper {
 
-    public SpreadSheet maptoEntity(Spreadsheet googleSpreadsheet){
+    public SpreadSheetApp maptoEntity(Spreadsheet googleSpreadsheet){
 
-        return SpreadSheet.builder()
+        return SpreadSheetApp.builder()
                 .spreadsheetId(googleSpreadsheet.getSpreadsheetId())
                 .title(googleSpreadsheet.getProperties().getTitle())
                 .sheets(new ArrayList<>())


### PR DESCRIPTION
    - Modified GoogleSheetMapper to map Google Sheets API objects to SheetApp instead of Sheet.
    - Updated GoogleSpreadsheetMapper to map Google Spreadsheet API objects to SpreadSheetApp instead of SpreadSheet.
    - Adjusted method signatures and return types to reflect the renamed entity classes.
    - Ensured consistent usage of SheetApp and SpreadSheetApp across the mapper layer for clarity and alignment with domain model changes.