### PR TITLE
feat: rename entities and improve spreadsheet save logic

### DIFF
--- a/src/main/java/com/demo/sheetsync/controller/SpreadSheetController.java
+++ b/src/main/java/com/demo/sheetsync/controller/SpreadSheetController.java
@@ -1,6 +1,6 @@
 package com.demo.sheetsync.controller;
 
-import com.demo.sheetsync.model.entity.dto.response.SpreadSheetDataResponse;
+import com.demo.sheetsync.model.dto.response.SpreadSheetResponse;
 import com.demo.sheetsync.service.SpreadSheetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +14,7 @@ public class SpreadSheetController {
     private final SpreadSheetService service;
 
     @GetMapping("/{spreadSheetId}")
-    public ResponseEntity<SpreadSheetDataResponse> save(@PathVariable String spreadSheetId) {
+    public ResponseEntity<SpreadSheetResponse> save(@PathVariable String spreadSheetId) {
 
         return ResponseEntity.ok(
                 service.saveSpreadSheet(spreadSheetId)

--- a/src/main/java/com/demo/sheetsync/exception/NotFoundException.java
+++ b/src/main/java/com/demo/sheetsync/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package com.demo.sheetsync.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND)
+public class NotFoundException extends RuntimeException{
+
+    public NotFoundException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/demo/sheetsync/model/dto/request/SpreadSheetDataRequest.java
+++ b/src/main/java/com/demo/sheetsync/model/dto/request/SpreadSheetDataRequest.java
@@ -1,4 +1,4 @@
-package com.demo.sheetsync.model.entity.dto.request;
+package com.demo.sheetsync.model.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/demo/sheetsync/model/dto/response/SpreadSheetResponse.java
+++ b/src/main/java/com/demo/sheetsync/model/dto/response/SpreadSheetResponse.java
@@ -1,6 +1,6 @@
 package com.demo.sheetsync.model.dto.response;
 
-import com.demo.sheetsync.model.entity.Sheet;
+import com.demo.sheetsync.model.entity.SheetApp;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,11 +12,11 @@ import java.util.List;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class SpreadSheetDataResponse {
+public class SpreadSheetResponse {
 
     private String spreadsheetId;
 
     private String title;
 
-    private List<Sheet> sheets;
+    private List<SheetApp> sheets;
 }

--- a/src/main/java/com/demo/sheetsync/model/entity/SpreadSheet.java
+++ b/src/main/java/com/demo/sheetsync/model/entity/SpreadSheet.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class SpreadSheet {
+public class SpreadSheetApp {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,6 +29,6 @@ public class SpreadSheet {
     private String title;
 
     @OneToMany(mappedBy = "spreadSheet", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Sheet> sheets;
+    private List<SheetApp> sheets;
 
 }

--- a/src/main/java/com/demo/sheetsync/model/mapper/GoogleSpreadsheetMapper.java
+++ b/src/main/java/com/demo/sheetsync/model/mapper/GoogleSpreadsheetMapper.java
@@ -1,6 +1,6 @@
 package com.demo.sheetsync.model.mapper;
 
-import com.demo.sheetsync.model.entity.SpreadSheet;
+import com.demo.sheetsync.model.entity.SpreadSheetApp;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,9 +11,9 @@ import java.util.ArrayList;
 @RequiredArgsConstructor
 public class GoogleSpreadsheetMapper {
 
-    public SpreadSheet maptoEntity(Spreadsheet googleSpreadsheet){
+    public SpreadSheetApp maptoEntity(Spreadsheet googleSpreadsheet){
 
-        return SpreadSheet.builder()
+        return SpreadSheetApp.builder()
                 .spreadsheetId(googleSpreadsheet.getSpreadsheetId())
                 .title(googleSpreadsheet.getProperties().getTitle())
                 .sheets(new ArrayList<>())

--- a/src/main/java/com/demo/sheetsync/model/mapper/SpreadSheetMapper.java
+++ b/src/main/java/com/demo/sheetsync/model/mapper/SpreadSheetMapper.java
@@ -1,19 +1,31 @@
 package com.demo.sheetsync.model.mapper;
 
-import com.demo.sheetsync.model.entity.SpreadSheet;
+import com.demo.sheetsync.model.entity.SpreadSheetApp;
 import com.demo.sheetsync.model.dto.response.SpreadSheetResponse;
 import org.springframework.stereotype.Component;
 
-@Component
-public class SpreadSheetDataMapper {
+import java.util.ArrayList;
 
-    public SpreadSheetResponse toResponse(SpreadSheet spreadSheet){
+@Component
+public class SpreadSheetMapper {
+
+    public SpreadSheetResponse toResponse(SpreadSheetApp spreadSheet){
 
         return new SpreadSheetResponse(
                 spreadSheet.getSpreadsheetId(),
                 spreadSheet.getTitle(),
                 spreadSheet.getSheets()
         );
+
+    }
+
+    public SpreadSheetApp toEntity(SpreadSheetResponse response){
+
+        return SpreadSheetApp.builder()
+                .spreadsheetId(response.getSpreadsheetId())
+                .title(response.getTitle())
+                .sheets(new ArrayList<>())
+                .build();
 
     }
 }

--- a/src/main/java/com/demo/sheetsync/repository/SpreadSheetRepository.java
+++ b/src/main/java/com/demo/sheetsync/repository/SpreadSheetRepository.java
@@ -1,12 +1,14 @@
 package com.demo.sheetsync.repository;
 
-import com.demo.sheetsync.model.entity.SpreadSheet;
+import com.demo.sheetsync.model.entity.SpreadSheetApp;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface SpreadSheetRepository extends JpaRepository<SpreadSheet, Integer> {
+import java.util.Optional;
 
-    SpreadSheet findBySpreadsheetId(String spreadsheetId);
+@Repository
+public interface SpreadSheetRepository extends JpaRepository<SpreadSheetApp, Integer> {
+
+    Optional<SpreadSheetApp> findBySpreadsheetId(String spreadsheetId);
 
 }

--- a/src/main/java/com/demo/sheetsync/service/SpreadSheetService.java
+++ b/src/main/java/com/demo/sheetsync/service/SpreadSheetService.java
@@ -1,21 +1,20 @@
 package com.demo.sheetsync.service;
 
-import com.demo.sheetsync.exception.GoogleSheetAccessException;
-import com.demo.sheetsync.model.entity.SpreadSheet;
-import com.demo.sheetsync.model.entity.dto.mapper.GoogleSpreadsheetMapper;
-import com.demo.sheetsync.model.entity.dto.mapper.SpreadSheetDataMapper;
-import com.demo.sheetsync.model.entity.dto.request.SpreadSheetDataRequest;
-import com.demo.sheetsync.model.entity.dto.response.SpreadSheetDataResponse;
+import com.demo.sheetsync.exception.NotFoundException;
+import com.demo.sheetsync.model.entity.SheetApp;
+import com.demo.sheetsync.model.entity.SpreadSheetApp;
+import com.demo.sheetsync.model.mapper.GoogleSpreadsheetMapper;
+import com.demo.sheetsync.model.mapper.SheetMapper;
+import com.demo.sheetsync.model.mapper.SpreadSheetMapper;
+import com.demo.sheetsync.model.dto.response.SpreadSheetResponse;
 import com.demo.sheetsync.repository.SpreadSheetRepository;
-import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.List;
 
-import java.io.IOException;
+import static java.lang.String.format;
 
 @Service
 @RequiredArgsConstructor
@@ -23,20 +22,41 @@ public class SpreadSheetService {
 
     private final SpreadSheetRepository repository;
     private final GoogleSpreadsheetMapper googleSpreadsheetMapper;
-    private final SpreadSheetDataMapper spreadSheetDataMapper;
+    private final SpreadSheetMapper spreadSheetMapper;
     private final GoogleSheetsService googleSheetsService;
+    private final SheetService sheetService;
+    private final SheetMapper sheetMapper;
 
 
-    public SpreadSheetDataResponse saveSpreadSheet(String spreadSheetId)  {
+    public SpreadSheetResponse saveSpreadSheet(String spreadSheetId)  {
 
         Spreadsheet googleSpreadSheet = googleSheetsService
                 .getGoogleSpreadSheet(spreadSheetId);
 
-        SpreadSheet spreadSheet = googleSpreadsheetMapper.maptoEntity(googleSpreadSheet);
+        SpreadSheetApp spreadSheet = googleSpreadsheetMapper.maptoEntity(googleSpreadSheet);
 
-        return spreadSheetDataMapper
+        List<SheetApp> relatedSavedSheets = sheetService
+                .saveAllSheets(spreadSheet).stream()
+                .map(sheetMapper::toEntity)
+                .toList();
+
+        spreadSheet.setSheets(relatedSavedSheets);
+
+        return spreadSheetMapper
                 .toResponse(repository.save(spreadSheet));
+    }
 
+    public SpreadSheetResponse getSpreadSheet(String spreadSheetId){
+
+        SpreadSheetApp spreadSheet = repository.findBySpreadsheetId(spreadSheetId)
+                .orElseThrow(() -> {
+                    throw new NotFoundException(
+                            format("SpreadSheetApp with id %s not found," +
+                                    " please enter a valid one", spreadSheetId)
+                    );
+                });
+
+        return spreadSheetMapper.toResponse(spreadSheet);
     }
 
 

--- a/src/test/java/com/demo/sheetsync/repository/SpreadSheetRepositoryTest.java
+++ b/src/test/java/com/demo/sheetsync/repository/SpreadSheetRepositoryTest.java
@@ -1,10 +1,6 @@
 package com.demo.sheetsync.repository;
 
-import com.demo.sheetsync.model.entity.Sheet;
-import com.demo.sheetsync.model.entity.SpreadSheet;
-import com.google.api.services.sheets.v4.Sheets;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.boot.test.context.SpringBootTest;
 

--- a/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceIntegrationTest.java
+++ b/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceIntegrationTest.java
@@ -1,11 +1,10 @@
 package com.demo.sheetsync.service;
 
-import com.demo.sheetsync.model.entity.SpreadSheet;
-import com.demo.sheetsync.model.entity.dto.mapper.GoogleSpreadsheetMapper;
-import com.demo.sheetsync.model.entity.dto.request.SpreadSheetDataRequest;
-import com.demo.sheetsync.model.entity.dto.response.SpreadSheetDataResponse;
+import com.demo.sheetsync.model.dto.response.SheetResponse;
+import com.demo.sheetsync.model.dto.response.SpreadSheetResponse;
+import com.demo.sheetsync.model.entity.SpreadSheetApp;
+import com.demo.sheetsync.model.mapper.GoogleSpreadsheetMapper;
 import com.demo.sheetsync.repository.SpreadSheetRepository;
-import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
 import com.google.api.services.sheets.v4.model.SpreadsheetProperties;
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
@@ -52,7 +50,7 @@ public class SpreadSheetServiceIntegrationTest {
         googleSpreadsheet.setProperties(new SpreadsheetProperties()
                 .setTitle("test sheet"));
 
-        SpreadSheet entity = SpreadSheet.builder()
+        SpreadSheetApp entity = SpreadSheetApp.builder()
                 .id(null)
                 .spreadsheetId(spreadSheetId)
                 .title("test sheet")
@@ -67,7 +65,7 @@ public class SpreadSheetServiceIntegrationTest {
         when(googleMapper.maptoEntity(googleSpreadsheet)).thenReturn(entity);
 
         //When
-        SpreadSheetDataResponse result = service.saveSpreadSheet(spreadSheetId);
+        SpreadSheetResponse result = service.saveSpreadSheet(spreadSheetId);
 
         //Then
         assertNotNull(result);
@@ -75,9 +73,9 @@ public class SpreadSheetServiceIntegrationTest {
         assertEquals(spreadSheetId, result.getSpreadsheetId());
 
         //check persistence
-        List<SpreadSheet> all = repository.findAll();
+        List<SpreadSheetApp> all = repository.findAll();
         assertEquals(1, all.size());
-        SpreadSheet saved = all.get(0);
+        SpreadSheetApp saved = all.get(0);
         assertEquals("test sheet", saved.getTitle());
         assertEquals(spreadSheetId, saved.getSpreadsheetId());
     }

--- a/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceTest.java
+++ b/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceTest.java
@@ -1,12 +1,10 @@
 package com.demo.sheetsync.service;
 
-import com.demo.sheetsync.model.entity.SpreadSheet;
-import com.demo.sheetsync.model.entity.dto.mapper.GoogleSpreadsheetMapper;
-import com.demo.sheetsync.model.entity.dto.mapper.SpreadSheetDataMapper;
-import com.demo.sheetsync.model.entity.dto.request.SpreadSheetDataRequest;
-import com.demo.sheetsync.model.entity.dto.response.SpreadSheetDataResponse;
+import com.demo.sheetsync.model.dto.response.SpreadSheetResponse;
+import com.demo.sheetsync.model.entity.SpreadSheetApp;
+import com.demo.sheetsync.model.mapper.GoogleSpreadsheetMapper;
+import com.demo.sheetsync.model.mapper.SpreadSheetMapper;
 import com.demo.sheetsync.repository.SpreadSheetRepository;
-import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,13 +28,10 @@ class SpreadSheetServiceTest {
     GoogleSpreadsheetMapper googleSpreadsheetMapper;
 
     @Mock
-    SpreadSheetDataMapper spreadSheetDataMapper;
+    SpreadSheetMapper spreadSheetMapper;
 
     @Mock
     GoogleSheetsService googleSheetsService;
-
-    @Mock
-    Spreadsheet spreadsheet;
 
     @InjectMocks
     SpreadSheetService service;
@@ -49,12 +44,12 @@ class SpreadSheetServiceTest {
 
         Spreadsheet googleSpreadsheet = new Spreadsheet();
 
-        SpreadSheet spreadSheetEntity = new SpreadSheet();
+        SpreadSheetApp spreadSheetEntity = new SpreadSheetApp();
 
-        SpreadSheet savedEntity = new SpreadSheet();
+        SpreadSheetApp savedEntity = new SpreadSheetApp();
 
-        SpreadSheetDataResponse response =
-                new SpreadSheetDataResponse();
+        SpreadSheetResponse response =
+                new SpreadSheetResponse();
 
         when(googleSheetsService.getGoogleSpreadSheet(spreadSheetId))
                 .thenReturn(googleSpreadsheet);
@@ -65,11 +60,11 @@ class SpreadSheetServiceTest {
 
         when(repository.save(spreadSheetEntity)).thenReturn(savedEntity);
 
-        when(spreadSheetDataMapper
+        when(spreadSheetMapper
                 .toResponse(savedEntity)).thenReturn(response);
 
         //Act
-        SpreadSheetDataResponse result = service.saveSpreadSheet(spreadSheetId);
+        SpreadSheetResponse result = service.saveSpreadSheet(spreadSheetId);
 
         //Assert
         assertEquals(response, result);
@@ -80,7 +75,7 @@ class SpreadSheetServiceTest {
 
         verify(repository).save(spreadSheetEntity);
 
-        verify(spreadSheetDataMapper).toResponse(savedEntity);
+        verify(spreadSheetMapper).toResponse(savedEntity);
     }
 
 }


### PR DESCRIPTION
    - Renamed SpreadSheet to SpreadSheetApp and Sheet to SheetApp to clarify domain entities.

    - Updated DTOs and mappers to reflect new naming conventions.

    - Replaced SpreadSheetDataResponse with SpreadSheetResponse for consistency.

    Refactored SpreadSheetService to:

    - Delegate sheet saving to SheetService

    - Map saved sheets back to the entity before persisting

    - Add a new getSpreadSheet method with proper not-found handling.

    - Adjusted repository to return Optional for safer access.

    - Updated test classes to align with entity renaming and service changes.