### PR TITLE
refactor: rename variable for clarity and enhance test with full sheet mapping flow

### DIFF
--- a/src/main/java/com/demo/sheetsync/service/SpreadSheetService.java
+++ b/src/main/java/com/demo/sheetsync/service/SpreadSheetService.java
@@ -35,12 +35,12 @@ public class SpreadSheetService {
 
         SpreadSheetApp spreadSheet = googleSpreadsheetMapper.maptoEntity(googleSpreadSheet);
 
-        List<SheetApp> relatedSavedSheets = sheetService
+        List<SheetApp> relatedSheets = sheetService
                 .saveAllSheets(spreadSheet).stream()
                 .map(sheetMapper::toEntity)
                 .toList();
 
-        spreadSheet.setSheets(relatedSavedSheets);
+        spreadSheet.setSheets(relatedSheets);
 
         return spreadSheetMapper
                 .toResponse(repository.save(spreadSheet));


### PR DESCRIPTION
    - Renamed `relatedSavedSheets` to `relatedSheets` in `SpreadSheetService` for better readability.
    - Updated `SpreadSheetServiceTest` to include full mocking and verification of `SheetService` and `SheetMapper`, ensuring accurate sheet-to-entity mapping and improved test coverage.