### PR TITLE
refactor: decouple circular reference between SheetResponse and SpreadSheetApp and update mapping

### DIFF
--- a/src/main/java/com/demo/sheetsync/model/dto/response/SheetResponse.java
+++ b/src/main/java/com/demo/sheetsync/model/dto/response/SheetResponse.java
@@ -18,5 +18,4 @@ public class SheetResponse {
     private String title;
     private List<String> headers;
     private List<LinkedHashMap<String, Object>> rows;
-    private SpreadSheetApp spreadSheet;
 }

--- a/src/main/java/com/demo/sheetsync/model/dto/response/SpreadSheetResponse.java
+++ b/src/main/java/com/demo/sheetsync/model/dto/response/SpreadSheetResponse.java
@@ -18,5 +18,5 @@ public class SpreadSheetResponse {
 
     private String title;
 
-    private List<SheetApp> sheets;
+    private List<SheetResponse> sheets;
 }

--- a/src/main/java/com/demo/sheetsync/model/mapper/SheetMapper.java
+++ b/src/main/java/com/demo/sheetsync/model/mapper/SheetMapper.java
@@ -14,7 +14,6 @@ public class SheetMapper {
                 .title(sheet.getTitle())
                 .headers(sheet.getHeaders())
                 .rows(sheet.getRows())
-                .spreadSheet(sheet.getSpreadSheet())
                 .build();
     }
 
@@ -25,7 +24,6 @@ public class SheetMapper {
                 .title(response.getTitle())
                 .headers(response.getHeaders())
                 .rows(response.getRows())
-                .spreadSheet(response.getSpreadSheet())
                 .build();
     }
 

--- a/src/main/java/com/demo/sheetsync/model/mapper/SpreadSheetMapper.java
+++ b/src/main/java/com/demo/sheetsync/model/mapper/SpreadSheetMapper.java
@@ -1,20 +1,27 @@
 package com.demo.sheetsync.model.mapper;
 
+import com.demo.sheetsync.model.dto.response.SheetResponse;
 import com.demo.sheetsync.model.entity.SpreadSheetApp;
 import com.demo.sheetsync.model.dto.response.SpreadSheetResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 
 @Component
+@RequiredArgsConstructor
 public class SpreadSheetMapper {
+
+    private final SheetMapper sheetMapper;
 
     public SpreadSheetResponse toResponse(SpreadSheetApp spreadSheet){
 
         return new SpreadSheetResponse(
                 spreadSheet.getSpreadsheetId(),
                 spreadSheet.getTitle(),
-                spreadSheet.getSheets()
+                spreadSheet.getSheets().stream()
+                        .map(sheetMapper::toResponse)
+                        .toList()
         );
 
     }

--- a/src/main/java/com/demo/sheetsync/service/SpreadSheetService.java
+++ b/src/main/java/com/demo/sheetsync/service/SpreadSheetService.java
@@ -1,6 +1,7 @@
 package com.demo.sheetsync.service;
 
 import com.demo.sheetsync.exception.NotFoundException;
+import com.demo.sheetsync.model.dto.response.SheetResponse;
 import com.demo.sheetsync.model.entity.SheetApp;
 import com.demo.sheetsync.model.entity.SpreadSheetApp;
 import com.demo.sheetsync.model.mapper.GoogleSpreadsheetMapper;
@@ -25,8 +26,6 @@ public class SpreadSheetService {
     private final SpreadSheetMapper spreadSheetMapper;
     private final GoogleSheetsService googleSheetsService;
     private final SheetService sheetService;
-    private final SheetMapper sheetMapper;
-
 
     public SpreadSheetResponse saveSpreadSheet(String spreadSheetId)  {
 
@@ -35,15 +34,15 @@ public class SpreadSheetService {
 
         SpreadSheetApp spreadSheet = googleSpreadsheetMapper.maptoEntity(googleSpreadSheet);
 
-        List<SheetApp> relatedSheets = sheetService
-                .saveAllSheets(spreadSheet).stream()
-                .map(sheetMapper::toEntity)
-                .toList();
-
-        spreadSheet.setSheets(relatedSheets);
-
-        return spreadSheetMapper
+        SpreadSheetResponse response = spreadSheetMapper
                 .toResponse(repository.save(spreadSheet));
+
+        List<SheetResponse> relatedSheets = sheetService
+                .saveAllSheets(spreadSheet);
+
+        response.setSheets(relatedSheets);
+
+        return response;
     }
 
     public SpreadSheetResponse getSpreadSheet(String spreadSheetId){

--- a/src/test/java/com/demo/sheetsync/service/SheetServiceTest.java
+++ b/src/test/java/com/demo/sheetsync/service/SheetServiceTest.java
@@ -84,14 +84,12 @@ class SheetServiceTest {
         responseMappedSheet1.setTitle("sheet1 title");
         responseMappedSheet1.setHeaders(new ArrayList<>());
         responseMappedSheet1.setRows(new ArrayList<>());
-        responseMappedSheet1.setSpreadSheet(spreadSheet);
 
         SheetResponse responseMappedSheet2 = new SheetResponse();
         responseMappedSheet2.setSheetId(4321);
         responseMappedSheet2.setTitle("sheet2 title");
         responseMappedSheet2.setHeaders(new ArrayList<>());
         responseMappedSheet2.setRows(new ArrayList<>());
-        responseMappedSheet2.setSpreadSheet(spreadSheet);
 
         when(googleSheetsService.getGoogleSheets(spreadSheet.getSpreadsheetId()))
                 .thenReturn(List.of(googleSheet1, googleSheet2));

--- a/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceIntegrationTest.java
+++ b/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceIntegrationTest.java
@@ -75,15 +75,12 @@ public class SpreadSheetServiceIntegrationTest {
         sheetResponse1.setTitle("sheet1 title");
         sheetResponse1.setHeaders(new ArrayList<>());
         sheetResponse1.setRows(new ArrayList<>());
-        sheetResponse1.setSpreadSheet(spreadSheet);
 
         SheetResponse sheetResponse2 = new SheetResponse();
         sheetResponse2.setSheetId(4321);
         sheetResponse2.setTitle("sheet2 title");
         sheetResponse2.setHeaders(new ArrayList<>());
         sheetResponse2.setRows(new ArrayList<>());
-        sheetResponse2.setSpreadSheet(spreadSheet);
-
 
         when(googleSheetsService
                 .getGoogleSpreadSheet(spreadSheetId))


### PR DESCRIPTION
  - Removed `spreadSheet` field from `SheetResponse` to avoid circular reference and simplify DTO structure.
    - Adjusted `SheetMapper` to stop mapping the `spreadSheet` field in both directions.
    - Updated `SpreadSheetResponse` to use `List<SheetResponse>` instead of `List<SheetApp>`, allowing better separation between entity and response models.
    - Refactored `SpreadSheetMapper` to map nested `SheetApp` entities into `SheetResponse` using `SheetMapper`.
    - Simplified `SpreadSheetService.saveSpreadSheet` to build the response directly and then attach the related sheet responses.
    - Cleaned up test classes (`SheetServiceTest` and `SpreadSheetServiceIntegrationTest`) by removing unused or invalid references to `spreadSheet` in `SheetResponse`.