### PR TITLE
feat: enrich SheetApp with headers from Google Sheets and improve data fetching

### DIFF
--- a/src/main/java/com/demo/sheetsync/service/GoogleSheetsService.java
+++ b/src/main/java/com/demo/sheetsync/service/GoogleSheetsService.java
@@ -4,6 +4,7 @@ import com.demo.sheetsync.exception.GoogleSheetAccessException;
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.Sheet;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
+import com.google.api.services.sheets.v4.model.ValueRange;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +29,34 @@ public class GoogleSheetsService {
     protected List<Sheet> getGoogleSheets(String spreadSheetId){
 
         return tryGetGoogleSpreadSheet(spreadSheetId).getSheets();
+    }
+
+    protected List<List<Object>> getData(String spreadSheetId, String range){
+
+        return tryGetData(spreadSheetId, range).getValues();
+
+    }
+
+    private ValueRange tryGetData(String spreadSheetId, String range){
+
+        try{
+
+            return sheets.spreadsheets()
+                    .values()
+                    .get(spreadSheetId, range)
+                    .execute();
+
+        } catch(IOException e){
+
+            String msg = "Something went wrong retrieving the data from" +
+                    "spreadsheet with ID: "
+                    + spreadSheetId;
+
+            logger.error(msg, e);
+            throw new GoogleSheetAccessException(msg, e);
+        }
+
+
     }
 
     private Spreadsheet tryGetGoogleSpreadSheet(String spreadSheetId){

--- a/src/main/java/com/demo/sheetsync/service/SheetService.java
+++ b/src/main/java/com/demo/sheetsync/service/SheetService.java
@@ -9,6 +9,7 @@ import com.demo.sheetsync.repository.SheetRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -23,9 +24,13 @@ public class SheetService {
 
         List<SheetApp> sheets = googleSheetsService
                 .getGoogleSheets(spreadSheet.getSpreadsheetId())
-                .stream().map(sheet -> {
+                .stream().map(googleSheet -> {
 
-                    return googleSheetMapper.mapToEntity(sheet, spreadSheet);
+                    SheetApp sheet = googleSheetMapper.mapToEntity(googleSheet, spreadSheet);
+
+                    sheet.setHeaders(getHeaders(spreadSheet.getSpreadsheetId()));
+
+                    return sheet;
 
                 })
                 .toList();
@@ -35,13 +40,24 @@ public class SheetService {
                 .toList();
     }
 
-    public List<SheetApp> findAllBy(String spreadSheetId){
 
-        return null;
+    private List<String> getHeaders(String spreadSheetId) {
+
+        List<List<Object>> data = googleSheetsService
+                .getData(spreadSheetId, "Hoja 1!A1:C");
+
+        if(data == null || data.isEmpty())
+            return new ArrayList<>();
+
+        return data.get(0)
+                .stream()
+                .map(Object::toString)
+                .toList();
+    }
+
 
     }
 
 
 
 
-}


### PR DESCRIPTION
    - Added `getData` method in `GoogleSheetsService` to retrieve cell values from a given range using Google Sheets API.
    - Introduced private `getHeaders` method in `SheetService` to extract headers from the first row of the sheet using the `getData` method.
    - Enhanced sheet mapping logic in `SheetService.saveAllSheets` to assign headers directly from the sheet data (`A1:C` range on "Hoja 1").
    - Removed unused stub method `findAllBy` from `SheetService`.