### PR TITLE
feat: add sheet row mapping with headers as keys

### DIFF
--- a/src/main/java/com/demo/sheetsync/service/GoogleSheetsService.java
+++ b/src/main/java/com/demo/sheetsync/service/GoogleSheetsService.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -33,8 +34,10 @@ public class GoogleSheetsService {
 
     protected List<List<Object>> getData(String spreadSheetId, String range){
 
-        return tryGetData(spreadSheetId, range).getValues();
+        ValueRange googleData = tryGetData(spreadSheetId, range);
 
+        return googleData.isEmpty()?
+                new ArrayList<>() : googleData.getValues();
     }
 
     private ValueRange tryGetData(String spreadSheetId, String range){

--- a/src/main/java/com/demo/sheetsync/service/SheetService.java
+++ b/src/main/java/com/demo/sheetsync/service/SheetService.java
@@ -10,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +31,7 @@ public class SheetService {
                     SheetApp sheet = googleSheetMapper.mapToEntity(googleSheet, spreadSheet);
 
                     sheet.setHeaders(getHeaders(spreadSheet.getSpreadsheetId()));
+                    sheet.setRows(getData(sheet));
 
                     return sheet;
 
@@ -46,13 +49,38 @@ public class SheetService {
         List<List<Object>> data = googleSheetsService
                 .getData(spreadSheetId, "Hoja 1!A1:C");
 
-        if(data == null || data.isEmpty())
-            return new ArrayList<>();
-
         return data.get(0)
                 .stream()
                 .map(Object::toString)
                 .toList();
+    }
+
+    private List<LinkedHashMap<String, Object>> getData(SheetApp sheet){
+
+        String spreadSheetId = sheet.getSpreadSheet()
+                .getSpreadsheetId();
+
+        List<LinkedHashMap<String, Object>> data = new ArrayList<>();
+
+        LinkedHashMap<String, Object> row = new LinkedHashMap<>();
+
+        List<List<Object>> googleData = googleSheetsService
+                .getData(spreadSheetId, "Hoja 1!A2:C");
+
+            for(List<Object> googleRow : googleData){
+
+                for(int i = 0; i < sheet.getHeaders().size(); i++){
+
+                    row.put(sheet.getHeaders().get(i), googleRow.get(i));
+
+                }
+
+                data.add(row);
+
+        }
+
+    return data;
+
     }
 
 


### PR DESCRIPTION
    - Implemented `getData(SheetApp)` in `SheetService` to map each row using headers as keys and cell values as values, enabling structured data extraction.
    - Updated `saveAllSheets` to enrich each `SheetApp` with both headers and row content from the sheet.
    - Enhanced `getData` in `GoogleSheetsService` to return an empty list safely when no data is found, improving resilience.
    - Simplified `getHeaders` logic to directly extract the first row of data as headers.