### PR TITLE
Refactor spreadsheet endpoints: update save method to POST and add retrieval route

### DIFF
--- a/src/main/java/com/demo/sheetsync/controller/SpreadSheetController.java
+++ b/src/main/java/com/demo/sheetsync/controller/SpreadSheetController.java
@@ -14,7 +14,7 @@ public class SpreadSheetController {
     private final SpreadSheetService service;
 
     @GetMapping("/{spreadSheetId}")
-    public ResponseEntity<SpreadSheetResponse> save(@PathVariable String spreadSheetId) {
+    public ResponseEntity<SpreadSheetResponse> saveFromGoogleSheet(@PathVariable String spreadSheetId) {
 
         return ResponseEntity.ok(
                 service.saveSpreadSheet(spreadSheetId)

--- a/src/main/java/com/demo/sheetsync/controller/SpreadSheetController.java
+++ b/src/main/java/com/demo/sheetsync/controller/SpreadSheetController.java
@@ -13,12 +13,20 @@ public class SpreadSheetController {
 
     private final SpreadSheetService service;
 
-    @GetMapping("/{spreadSheetId}")
+    @PostMapping("persist/{spreadSheetId}")
     public ResponseEntity<SpreadSheetResponse> saveFromGoogleSheet(@PathVariable String spreadSheetId) {
 
         return ResponseEntity.ok(
                 service.saveSpreadSheet(spreadSheetId)
         );
 
+    }
+
+    @GetMapping("get/{spreadSheetId}")
+    public ResponseEntity<SpreadSheetResponse> getSpreadSheet(@PathVariable String spreadSheetId){
+
+        return ResponseEntity.ok(
+                service.getSpreadSheet(spreadSheetId)
+        );
     }
 }


### PR DESCRIPTION
- Changed the HTTP method for saveFromGoogleSheet from GET to POST and updated its route to /persist/{spreadSheetId} for clearer intent and RESTful consistency.

- Added a new GET endpoint /get/{spreadSheetId} to retrieve spreadsheet data using the getSpreadSheet method.