### PR TITLE
Replace Testcontainers with local PostgreSQL setup for testing

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: test
   config:
     import: optional:file:dev.env[.properties]
   application:

--- a/src/test/java/com/demo/sheetsync/SheetSyncApplicationTests.java
+++ b/src/test/java/com/demo/sheetsync/SheetSyncApplicationTests.java
@@ -3,8 +3,9 @@ package com.demo.sheetsync;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
-@Import(TestcontainersConfiguration.class)
+//@Import(TestcontainersConfiguration.class)
 @SpringBootTest
 class SheetSyncApplicationTests {
 

--- a/src/test/java/com/demo/sheetsync/TestSheetsyncApplication.java
+++ b/src/test/java/com/demo/sheetsync/TestSheetsyncApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.SpringApplication;
 public class TestSheetsyncApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.from(SheetSyncApplication::main).with(TestcontainersConfiguration.class).run(args);
+		SpringApplication.from(SheetSyncApplication::main).run(args);
 	}
 
 }

--- a/src/test/java/com/demo/sheetsync/TestcontainersConfiguration.java
+++ b/src/test/java/com/demo/sheetsync/TestcontainersConfiguration.java
@@ -1,4 +1,4 @@
-package com.demo.sheetsync;
+/*package com.demo.sheetsync;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -18,4 +18,4 @@ class TestcontainersConfiguration {
 				.withPassword("passTest");
 	}
 
-}
+}*/

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:tc:postgresql:15:///db_test
-    username: userTest
-    password: passTest
-    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:postgresql://localhost:5432/sheetsync_testdb
+    username: postgres
+    password: password
+    driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
This pull request modifies the testing configuration to simplify and speed up the test environment:

1. **Application Profile**

   * Set the active Spring profile to `test` in `application.yaml`.

2. **Testcontainers Deactivation**

   * Commented out `@Import(TestcontainersConfiguration.class)` in `SheetSyncApplicationTests`.
   * Removed `TestcontainersConfiguration` from the application startup in `TestSheetsyncApplication`.
   * Fully commented out the `TestcontainersConfiguration` class to prevent usage.

3. **Database Configuration Update**

   * Updated `application-test.yaml` to use a local PostgreSQL instance instead of a Testcontainers-managed one.

     * New connection URL: `jdbc:postgresql://localhost:5432/sheetsync_testdb`
     * Driver changed from `org.testcontainers.jdbc.ContainerDatabaseDriver` to `org.postgresql.Driver`.

These changes reduce complexity by avoiding container-based database provisioning during tests and allow direct use of a local PostgreSQL database.
