### PR TITLE
refactor(sheet): unify sheet identifiers and enhance endpoints

### DIFF
--- a/src/main/java/com/demo/sheetsync/SheetSyncApplication.java
+++ b/src/main/java/com/demo/sheetsync/SheetSyncApplication.java
@@ -2,7 +2,9 @@ package com.demo.sheetsync;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 @SpringBootApplication
 public class SheetSyncApplication {
 

--- a/src/main/java/com/demo/sheetsync/controller/SheetController.java
+++ b/src/main/java/com/demo/sheetsync/controller/SheetController.java
@@ -1,9 +1,11 @@
 package com.demo.sheetsync.controller;
 
+import com.demo.sheetsync.model.dto.response.SheetSummaryResponse;
 import com.demo.sheetsync.service.SheetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,10 +20,17 @@ public class SheetController {
 
     private final SheetService sheetService;
 
-    @GetMapping("/{sheetId}/data")
-    public Page<LinkedHashMap<String, Object>> getData(@PathVariable Integer sheetId,
+    @GetMapping("/{id}")
+    public ResponseEntity<SheetSummaryResponse> getById(Integer id){
+
+        return ResponseEntity.ok(sheetService.getSheetSummaryBy(id));
+
+    }
+
+    @GetMapping("/{id}/data")
+    public Page<LinkedHashMap<String, Object>> getData(@PathVariable Integer id,
                                                        Pageable pageable){
 
-        return sheetService.getDataFrom(sheetId, pageable);
+        return sheetService.getDataFrom(id, pageable);
     }
 }

--- a/src/main/java/com/demo/sheetsync/controller/SpreadSheetController.java
+++ b/src/main/java/com/demo/sheetsync/controller/SpreadSheetController.java
@@ -22,8 +22,8 @@ public class SpreadSheetController {
 
     }
 
-    @GetMapping("get/{spreadSheetId}")
-    public ResponseEntity<SpreadSheetResponse> getSpreadSheet(@PathVariable String spreadSheetId){
+    @GetMapping("{spreadSheetId}")
+    public ResponseEntity<SpreadSheetResponse> getBySpreadSheetId(@PathVariable String spreadSheetId){
 
         return ResponseEntity.ok(
                 service.getSpreadSheet(spreadSheetId)

--- a/src/main/java/com/demo/sheetsync/model/dto/response/SheetSummaryResponse.java
+++ b/src/main/java/com/demo/sheetsync/model/dto/response/SheetSummaryResponse.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Builder
 public class SheetSummaryResponse {
 
-    private Integer sheetId;
+    private Integer id;
     private String title;
     private List<String> headers;
     private String spreadsheetId;

--- a/src/main/java/com/demo/sheetsync/model/entity/SheetApp.java
+++ b/src/main/java/com/demo/sheetsync/model/entity/SheetApp.java
@@ -9,7 +9,6 @@ import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 
 @Entity

--- a/src/main/java/com/demo/sheetsync/model/mapper/GoogleSheetMapper.java
+++ b/src/main/java/com/demo/sheetsync/model/mapper/GoogleSheetMapper.java
@@ -15,7 +15,7 @@ public class GoogleSheetMapper {
                                 SpreadSheetApp parentSpreadSheet){
 
         return SheetApp.builder()
-                .sheetId(googleSheet.getProperties().getSheetId())
+                .id(googleSheet.getProperties().getSheetId())
                 .title(googleSheet.getProperties().getTitle())
                 .headers(new ArrayList<>())
                 .rows(new ArrayList<>())

--- a/src/main/java/com/demo/sheetsync/model/mapper/SheetMapper.java
+++ b/src/main/java/com/demo/sheetsync/model/mapper/SheetMapper.java
@@ -10,7 +10,7 @@ public class SheetMapper {
     public SheetSummaryResponse toSummaryResponse(SheetApp sheet){
 
         return SheetSummaryResponse.builder()
-                .sheetId(sheet.getSheetId())
+                .id(sheet.getId())
                 .title(sheet.getTitle())
                 .headers(sheet.getHeaders())
                 .spreadsheetId(sheet.getSpreadSheet().getSpreadsheetId())
@@ -20,7 +20,7 @@ public class SheetMapper {
     public SheetApp toEntity(SheetSummaryResponse response){
 
         return SheetApp.builder()
-                .sheetId(response.getSheetId())
+                .id(response.getId())
                 .title(response.getTitle())
                 .headers(response.getHeaders())
                 .build();

--- a/src/main/java/com/demo/sheetsync/repository/SheetRepository.java
+++ b/src/main/java/com/demo/sheetsync/repository/SheetRepository.java
@@ -14,15 +14,15 @@ public interface SheetRepository extends JpaRepository<SheetApp, Integer> {
 
     @Query("""
             SELECT new com.demo.sheetsync.model.dto.response.SheetSummaryResponse(
-                s.sheetId, s.title, s.headers, s.spreadSheet.spreadsheetId
+                s.id, s.title, s.headers, s.spreadSheet.spreadsheetId
             )
             FROM SheetApp s
             """)
-    Optional<SheetSummaryResponse> findSummaryByTitle(String title);
+    Optional<SheetSummaryResponse> findSummaryById(Integer id);
 
     @Query("""
             SELECT new com.demo.sheetsync.model.dto.response.SheetSummaryResponse(
-                s.sheetId, s.title, s.headers, s.spreadSheet.spreadsheetId
+                s.id, s.title, s.headers, s.spreadSheet.spreadsheetId
             )
             FROM SheetApp s
             """)

--- a/src/main/java/com/demo/sheetsync/service/SheetService.java
+++ b/src/main/java/com/demo/sheetsync/service/SheetService.java
@@ -55,11 +55,11 @@ public class SheetService {
         return sheetRepository.findAllSheetSummaries();
     }
 
-    public SheetSummaryResponse getSheetSummaryBy(String title){
+    public SheetSummaryResponse getSheetSummaryBy(Integer id){
 
-        return sheetRepository.findSummaryByTitle(title)
+        return sheetRepository.findSummaryById(id)
                 .orElseThrow(() -> new NotFoundException(
-                        format("Sheet with title %s not found", title)
+                        format("Sheet with title %s not found", id)
                 ));
     }
 
@@ -127,7 +127,7 @@ public class SheetService {
 
         List<List<Object>> data = googleSheetsService
                 .getData(spreadSheetId,
-                        sheetTitle + "!A1:C");
+                        sheetTitle + "!A1:J");
 
         return data.get(0)
                 .stream()
@@ -139,7 +139,7 @@ public class SheetService {
 
         return googleSheetsService
                 .getData(sheet.getSpreadSheet().getSpreadsheetId(),
-                        sheet.getTitle() + "!A2:C"
+                        sheet.getTitle() + "!A2:J"
                 );
 
     }

--- a/src/test/java/com/demo/sheetsync/repository/SheetRepositoryTest.java
+++ b/src/test/java/com/demo/sheetsync/repository/SheetRepositoryTest.java
@@ -64,7 +64,7 @@ class SheetRepositoryTest {
 
         //Save the SheetApp with the related SpreadSheetApp saved previously
         SheetApp sheet = SheetApp.builder()
-                .sheetId(1234)
+                .id(1234)
                 .headers(headers)
                 .spreadSheet(spreadSheet)
                 .title("testTittle")

--- a/src/test/java/com/demo/sheetsync/service/SheetServiceTest.java
+++ b/src/test/java/com/demo/sheetsync/service/SheetServiceTest.java
@@ -62,7 +62,7 @@ class SheetServiceTest {
         googleSheet2.setProperties(sheetProps2);
 
         SheetApp mappedSheet1 = SheetApp.builder()
-                .sheetId(1234)
+                .id(1234)
                 .title("sheet1 title")
                 .rows(new ArrayList<>())
                 .headers(new ArrayList<>())
@@ -70,7 +70,7 @@ class SheetServiceTest {
                 .build();
 
         SheetApp mappedSheet2 = SheetApp.builder()
-                .sheetId(4321)
+                .id(4321)
                 .title("sheet2 title")
                 .rows(new ArrayList<>())
                 .headers(new ArrayList<>())
@@ -78,12 +78,12 @@ class SheetServiceTest {
                 .build();
 
         SheetSummaryResponse responseMappedSheet1 = new SheetSummaryResponse();
-        responseMappedSheet1.setSheetId(1234);
+        responseMappedSheet1.setId(1234);
         responseMappedSheet1.setTitle("sheet1 title");
         responseMappedSheet1.setHeaders(new ArrayList<>());
 
         SheetSummaryResponse responseMappedSheet2 = new SheetSummaryResponse();
-        responseMappedSheet2.setSheetId(4321);
+        responseMappedSheet2.setId(4321);
         responseMappedSheet2.setTitle("sheet2 title");
         responseMappedSheet2.setHeaders(new ArrayList<>());
 

--- a/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceIntegrationTest.java
+++ b/src/test/java/com/demo/sheetsync/service/SpreadSheetServiceIntegrationTest.java
@@ -67,12 +67,12 @@ public class SpreadSheetServiceIntegrationTest {
                 .build();
 
         SheetSummaryResponse sheetSummaryResponse1 = new SheetSummaryResponse();
-        sheetSummaryResponse1.setSheetId(1234);
+        sheetSummaryResponse1.setId(1234);
         sheetSummaryResponse1.setTitle("sheet1 title");
         sheetSummaryResponse1.setHeaders(new ArrayList<>());
 
         SheetSummaryResponse sheetSummaryResponse2 = new SheetSummaryResponse();
-        sheetSummaryResponse2.setSheetId(4321);
+        sheetSummaryResponse2.setId(4321);
         sheetSummaryResponse2.setTitle("sheet2 title");
         sheetSummaryResponse2.setHeaders(new ArrayList<>());
 


### PR DESCRIPTION
    - Enable Spring Data Web support for pageable DTO serialization
    - Rename `sheetId` to `id` across entity, DTOs, mappers, repository, and tests
    - Update SheetController:
      - Add `GET /{id}` endpoint to fetch sheet summary by ID
      - Update `/{id}/data` endpoint to use ID instead of title
    - Adjust SheetService and repository to query by ID instead of title
    - Extend data range fetched from Google Sheets (A1:J and A2:J)
    - Simplify SpreadSheetController `GET` endpoint path
    - Clean up unused imports and align test cases with new field naming